### PR TITLE
[feature] dynamically set Violet Rails Root (#15)

### DIFF
--- a/Violet Rails.xcodeproj/project.pbxproj
+++ b/Violet Rails.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		3E2A29172868944800585E9E /* Violet_RailsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2A29162868944800585E9E /* Violet_RailsUITests.swift */; };
 		3E2A29192868944800585E9E /* Violet_RailsUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2A29182868944800585E9E /* Violet_RailsUITestsLaunchTests.swift */; };
 		3E46E78A28689F8E00894CF6 /* Turbo in Frameworks */ = {isa = PBXBuildFile; productRef = 3E46E78928689F8E00894CF6 /* Turbo */; };
+		D4C318CE29D7228100EA95CE /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C318CD29D7228100EA95CE /* App.swift */; };
+		D4C318D029D7242100EA95CE /* NavigationTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C318CF29D7242100EA95CE /* NavigationTab.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +52,8 @@
 		3E2A29122868944800585E9E /* Violet RailsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Violet RailsUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E2A29162868944800585E9E /* Violet_RailsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Violet_RailsUITests.swift; sourceTree = "<group>"; };
 		3E2A29182868944800585E9E /* Violet_RailsUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Violet_RailsUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		D4C318CD29D7228100EA95CE /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+		D4C318CF29D7242100EA95CE /* NavigationTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTab.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,6 +105,7 @@
 		3E2A28F42868944600585E9E /* Violet Rails */ = {
 			isa = PBXGroup;
 			children = (
+				D4C318CB29D7226F00EA95CE /* Common */,
 				3E2A28F52868944600585E9E /* AppDelegate.swift */,
 				3E2A28F72868944600585E9E /* SceneDelegate.swift */,
 				3E2A28F92868944600585E9E /* ViewController.swift */,
@@ -127,6 +132,23 @@
 				3E2A29182868944800585E9E /* Violet_RailsUITestsLaunchTests.swift */,
 			);
 			path = "Violet RailsUITests";
+			sourceTree = "<group>";
+		};
+		D4C318CB29D7226F00EA95CE /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				D4C318CC29D7227400EA95CE /* Constants */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		D4C318CC29D7227400EA95CE /* Constants */ = {
+			isa = PBXGroup;
+			children = (
+				D4C318CD29D7228100EA95CE /* App.swift */,
+				D4C318CF29D7242100EA95CE /* NavigationTab.swift */,
+			);
+			path = Constants;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -268,7 +290,9 @@
 			files = (
 				3E2A28FA2868944600585E9E /* ViewController.swift in Sources */,
 				3E2A28F62868944600585E9E /* AppDelegate.swift in Sources */,
+				D4C318D029D7242100EA95CE /* NavigationTab.swift in Sources */,
 				3E2A28F82868944600585E9E /* SceneDelegate.swift in Sources */,
+				D4C318CE29D7228100EA95CE /* App.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Violet Rails/Common/Constants/App.swift
+++ b/Violet Rails/Common/Constants/App.swift
@@ -1,0 +1,12 @@
+//
+//  App.swift
+//  Violet Rails
+//
+//  Created by Joses Solmaximo on 31/03/23.
+//
+
+import Foundation
+
+struct App {
+    public static let ENDPOINT = "https://violet.restarone.solutions"
+}

--- a/Violet Rails/Common/Constants/NavigationTab.swift
+++ b/Violet Rails/Common/Constants/NavigationTab.swift
@@ -1,0 +1,19 @@
+//
+//  NavigationTab.swift
+//  Violet Rails
+//
+//  Created by Joses Solmaximo on 31/03/23.
+//
+
+import Foundation
+
+struct NavigationTab {
+    var title: String
+    var path: String
+}
+
+let navigationTabs: [NavigationTab] = [
+    .init(title: "Home", path: ""),
+    .init(title: "Blog", path: "/blog"),
+    .init(title: "Forum", path: "/forum"),
+]

--- a/Violet Rails/SceneDelegate.swift
+++ b/Violet Rails/SceneDelegate.swift
@@ -8,7 +8,7 @@
 import UIKit
 import Turbo
 import WebKit
-let violetRailsApp = "https://violet.restarone.solutions"
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     private lazy var navigationController = ViewController()
@@ -30,7 +30,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         navigationController.pushViewController(viewController, animated: true)
         
-        visit(url: URL(string: violetRailsApp)!)
+        visit(url: URL(string: App.ENDPOINT)!)
     }
     
     private func visit(url: URL) {
@@ -64,16 +64,10 @@ extension SceneDelegate: SessionDelegate {
 
 extension SceneDelegate: UITabBarDelegate {
     func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
-        switch(item.tag) {
-        case 0:
-            visit(url: URL(string: "\(violetRailsApp)")!)
-        case 1:
-            visit(url: URL(string: "\(violetRailsApp)/blog")!)
-        case 2:
-            visit(url: URL(string: "\(violetRailsApp)/forum")!)
-        case 3:
-            visit(url: URL(string: "\(violetRailsApp)")!)
-        default:
+        if let selectedTab = navigationTabs.first(where: { $0.title == item.title }),
+           let url = URL(string: "\(App.ENDPOINT)\(selectedTab.path)"){
+            visit(url: url)
+        } else {
             print("unhandled tab bar selection error")
         }
     }

--- a/Violet Rails/ViewController.swift
+++ b/Violet Rails/ViewController.swift
@@ -9,9 +9,6 @@ import UIKit
 
 class ViewController: UINavigationController, UITabBarDelegate {
     let tabBar = UITabBar()
-    let home = UITabBarItem(title: "Home",image: .checkmark, tag: 0)
-    let blog = UITabBarItem(title: "Blog", image: .checkmark, tag: 1)
-    let forum = UITabBarItem(title: "Forum", image: .checkmark, tag: 2)
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .darkContent
@@ -21,7 +18,9 @@ class ViewController: UINavigationController, UITabBarDelegate {
         super.viewDidLoad()
         
         tabBar.translatesAutoresizingMaskIntoConstraints = false
-        tabBar.items = [home, blog, forum]
+        tabBar.items = navigationTabs.enumerated().map({ index, tab in
+            UITabBarItem(title: tab.title, image: .checkmark, tag: index)
+        })
         
         self.view.addSubview(tabBar)
         


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails_ios_client/issues/2

Added variables to store root url and tabs.

Edit the URL in `ENDPOINT` to point to a different website. <img width="582" alt="image" src="https://user-images.githubusercontent.com/112497883/229297052-539f31cd-1481-488b-823d-24fcb9e1a931.png">

You can customize the tab navigation by removing, editing or adding `NavigationTab` to `navigationTabs` array. <img width="626" alt="image" src="https://user-images.githubusercontent.com/112497883/229155259-7cc356cb-0dfe-474d-ad65-2fcb83e96da8.png">